### PR TITLE
Fixed typos in the names of dependent modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,14 +25,14 @@ except IOError:
 
 install_requires = [
     'setuptools >= 0.8',
-    'Pyramid >= 1.5a4',
+    'pyramid >= 1.5a4',
     'pyramid_mako',
     'sqlalchemy >= 0.9.3',
     'Mako >= 0.3.6', # strict_undefined
     'PasteDeploy >= 1.5.0', # py3 compat
     'purl >= 0.5',
     'path.py',
-    'pyramid-exclog',
+    'pyramid_exclog',
     'zope.sqlalchemy',
     'WebTest',
     'six',
@@ -50,9 +50,9 @@ install_requires = [
 ]
 
 if not PY3:
-    install_requires.extend('xlrd xlwt Babel pyx==0.12.1'.split())
+    install_requires.extend('xlrd xlwt Babel PyX==0.12.1'.split())
 else:
-    install_requires.extend('pyx>=0.13'.split())
+    install_requires.extend('PyX>=0.13'.split())
 
 tests_require = [
     'WebTest >= 1.3.1', # py3 compat


### PR DESCRIPTION
I had to do these changes to install the clld module with install.py on our server cluster. I'm not sure whether this is normal or anything, but I thought you might be interested in any case.
