### PR TITLE
Added a contrib file, removed from README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+Contributing
+------------
+
+We follow the development model outlined here http://nvie.com/posts/a-successful-git-branching-model/ - if only because it's rather well documented.
+
+So never commit to master unless you want to make a release.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,3 @@ Cite
 
 Version 0.25: 
 [![DOI](https://zenodo.org/badge/5142/clld/clld.svg)](http://dx.doi.org/10.5281/zenodo.13747)
-
-
-Contributing
-------------
-
-We follow the development model outlined here http://nvie.com/posts/a-successful-git-branching-model/ - if only because it's rather well documented.
-
-So never commit to master unless you want to make a release.
-


### PR DESCRIPTION
This will make 'Please check the contributing guidelines for this repo'
appear when users submit a PR on GitHub. See https://github.com/blog/1184-contributing-guidelines

Hopefully, this will stop PRs to master, not that there have been many of those.