### PR TITLE
update package dev documentation and scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ pip-log.txt
 
 # Unit test / coverage reports
 .coverage
+/htmlcov/
 .jscoverage
 .tox
 nosetests.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,13 @@
 Contributing
 ------------
 
-We follow the development model outlined here http://nvie.com/posts/a-successful-git-branching-model/ - if only because it's rather well documented.
+Development envionment:
 
-So never commit to master unless you want to make a release.
+```sh
+$ pip install virtualenv  # might require sudo/admin privileges
+$ git clone https://github.com/clld/clld.git
+$ cd clld
+$ python -m virtualenv .venv
+$ source .venv/bin/activate  # Windows: .venv\Scripts\activate.bat
+$ pip install -r requirements.txt  # installs the cloned version with dev-tools in development mode
+```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,73 +2,73 @@ Releasing clld
 ==============
 
 - Update translations
-```
+```shell
 python setup.py extract_messages
 python setup.py update_catalog
 python setup.py compile_catalog
 ```
 
-- Make sure all changes are committed and pushed with a *.devN version number.
+- Make sure all changes are committed and pushed with a `*.devN` version number.
 
 - Do platform test via tox (making sure statement coverage is >= 99%):
-```
+```shell
 tox -r
 ```
 
 - Make sure all scaffold tests pass (Py 2.7, 3.4): After pushing the develop branch run
-```
+```shell
 ./venvs/clld/clld/build.sh "<rel-no>.dev0"
 ```
 
 - Make sure javascript and css can be minified:
-```
+```shell
 webassets -m clld.web.assets build
 rm -i src/clld/web/static/*/packed.*
 ```
 
 - Make sure javascript tests pass with coverage of clld.js at > 82%:
-```
+```shell
 java -jar tools/jsTestDriver/JsTestDriver-1.3.5.jar --tests all --browser chromium-browser --port 9877
 ```
 
 - Make sure flake8 passes
-```
+```shell
 flake8 src/
 ```
 
 - Make sure docs render OK
-```
+```shell
 cd docs
 make clean html
 cd ..
 ```
 
-- Update the version number, by removing the trailing `.dev0`:
-  - `src/clld/__init__.py`
+- Update the version number, by removing the trailing `.dev0` in:
   - `setup.py`
+  - `src/clld/__init__.py`
   - `docs/conf.py`
 
 - Change CHANGES.rst heading to reflect the new version number.
 
-- Bump version number:
-```
-git commit -a -m"bumped version number"
+- Create the release commit:
+```shell
+git commit -a -m "release <VERSION>"
 ```
 
 - Create a release tag:
-```
-git tag -a v<version> -m"..."
+```shell
+git tag -a v<VERSION> -m "<VERSION> release"
 ```
 
 - Push to github:
-```
+```shell
 git push origin
-git push --tags
+git push --tags origin
 ```
 
 - Release to PyPI:
-```
-git checkout tags/v$1
+```shell
+git checkout tags/v<VERSION>
 rm dist/*
 python setup.py sdist bdist_wheel
 twine upload dist/*
@@ -77,7 +77,15 @@ twine upload dist/*
 - Re-release using the same tag on GitHub, to trigger the ZENODO hook.
   update the DOI badge.
 
-- Update the version number to the new development cycle:
+- Append `.dev0` to the version number for the new development cycle:
   - `src/clld/__init__.py`
   - `setup.py`
   - `docs/conf.py`
+
+- Add a new `.dev0`version heading to CHANGES.rst for the new development version (unreleased).
+
+- Commit/push the version change:
+```shell
+git commit -m "bump version for development"
+git push origin
+```

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -18,14 +18,18 @@ Installation
 
 To install the python package from pypi run
 
-    pip install clld
+.. code:: bash
+
+    $ pip install clld
 
 To install from a git repository (if you want to hack on ``clld``),
-you may run the following commands in an activated `virtualenv <http://www.virtualenv.org/en/latest/>`_::
+you may run the following commands in an activated `virtualenv <http://www.virtualenv.org/en/latest/>`_:
 
-    git clone git@github.com:clld/clld.git
-    cd clld
-    pip install -e .[dev,test]
+.. code:: bash
+
+    $ git clone https://github.com/clld/clld.git
+    $ cd clld
+    $ pip install -r requirements.txt
 
 Alternatively, you may want to fork ``clld`` first and then work with your fork.
 
@@ -38,9 +42,11 @@ A ``clld`` app is a python package implementing a
 web application.
 
 The ``clld`` package provides a pyramid application scaffold to create the initial package directory
-layout for a ``clld`` app::
+layout for a ``clld`` app:
 
-    pcreate -t clld_app myapp
+.. code:: bash
+
+    $ pcreate -t clld_app myapp
 
 .. note::
 
@@ -83,10 +89,12 @@ This will create a python package ``myapp`` with the following layout::
     └── setup.py
 
 
-Running::
+Running
 
-    cd myapp
-    pip install -e .[dev,test]
+.. code:: bash
+
+    $ cd myapp
+    $ pip install -r requirements.txt
 
 will install your app as Python package in development mode, i.e. will create a link to
 your app's code in the ``site-packages`` directory.
@@ -96,9 +104,11 @@ Now edit the `configuration file <http://docs.pylonsproject.org/projects/pyramid
 The `SQLAlchemy engine URL <http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html>`_ given in this
 setting must point to an existing (but empty) database if the ``postgresql`` dialect is chosen.
 
-Running::
+Running
 
-    python myapp/scripts/initializedb.py development.ini
+.. code:: bash
+
+    $ python myapp/scripts/initializedb.py development.ini
 
 will then create the database for your app. Whenever you edit the database initialization
 script, you have to re-run the above command.
@@ -109,9 +119,11 @@ script, you have to re-run the above command.
     an existing database, so before running it, you have to drop and re-create and empty
     database "by hand".
 
-You are now ready to run::
+You are now ready to run
 
-    pserve --reload development.ini
+.. code:: bash
+
+    $ pserve --reload development.ini
 
 and navigate with your browser to http://127.0.0.1:6543 to visit your application.
 
@@ -123,9 +135,11 @@ Populating the database
 
 The ``clld`` framework does not provide any GUI or web interface for populating the database.
 Instead, this is assumed to be done with a script.
-You can edit ``clld/scripts/initializedb.py`` to fill the database with your data and run::
+You can edit ``clld/scripts/initializedb.py`` to fill the database with your data and run
 
-    python myapp/scripts/initializedb.py development.ini
+.. code:: bash
+
+    $ python myapp/scripts/initializedb.py development.ini
 
 Adding objects to the database is done by instantiating model objects and
 `adding them <http://docs.sqlalchemy.org/en/rel_0_9/orm/tutorial.html#adding-new-objects>`_

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# development environment: install in development mode
+-e .[dev,test,docs]

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,11 +31,17 @@ universal = 1
 [tool:pytest]
 minversion = 3.1
 testpaths = tests
-mock_use_standalone_module = true
 filterwarnings =
     ignore::sqlalchemy.exc.SAWarning
 addopts =
     --appini=tests/test.ini
-    --cov=clld
-    --cov-report term-missing
+    --cov
+    --cov-report=term
+    --cov-report=html
+mock_use_standalone_module = true
 
+[coverage:run]
+source = clld
+
+[coverage:report]
+show_missing = true

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
@@ -72,9 +73,11 @@ setup(
     install_requires=install_requires,
     extras_require={
         'dev': [
-            'waitress', 
-            'flake8', 
-            'wheel', 
+            'waitress',
+            'pyramid_debugtoolbar',
+            'tox',
+            'flake8',
+            'wheel',
             'twine',
         ],
         'test': [
@@ -104,4 +107,5 @@ setup(
         clld-google-books = clld.scripts.cli:google_books
         clld-internetarchive = clld.scripts.cli:internetarchive
         clld-create-downloads = clld.scripts.cli:create_downloads
-    """)
+    """
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,7 @@
 [tox]
-envlist =
-    py34,py27
+envlist = py{27,34,35,36}
+skip_missing_interpreters = true
 
 [testenv]
-commands =
-    python -m pytest {posargs}
-deps =
-    xlrd
-    pytest
-    mock
-    coverage
-    pytest-clld
-    pytest-cov
-    pytest-mock
-
-[testenv:py34]
-basepython = python3.4
-
-[testenv:py27]
-basepython = python2.7
-
+extras = test
+commands = pytest {posargs}


### PR DESCRIPTION
- use requirements.txt to recreate the dev environment
- replace branching model infos with development quickstart
- add development version bump commit to release procedure
- make tox.ini simpler and more widely applicable
- use https for git clone (git@ requires repo write access)