### PR TITLE
drop whitespace before punctuation in license footer

### DIFF
--- a/src/clld/web/templates/app.mako
+++ b/src/clld/web/templates/app.mako
@@ -157,8 +157,7 @@
                             <br />
                             is licensed under a
                             <a rel="license" href="${request.dataset.license}">
-                                ${request.dataset.jsondata.get('license_name', request.dataset.license)}
-                            </a>.
+                                ${request.dataset.jsondata.get('license_name', request.dataset.license)}</a>.
                         </div>
                         <div class="span3" style="text-align: right;">
                             <a href="${request.route_url('legal')}">disclaimer</a>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,14 +6,12 @@ import os
 import pytest
 from clldutils.path import Path
 from sqlalchemy import Column, Unicode, Integer, ForeignKey
-from clld.db.meta import CustomModelMixin, DBSession
+from clld.db.meta import CustomModelMixin, DBSession, VersionedDBSession
 from clld.db.models import common
 from clld.db.util import set_alembic_version
 from clld.scripts.util import Data
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
-
-pytest_plugins = ["clld"]
 
 
 class CustomLanguage(CustomModelMixin, common.Language):
@@ -174,6 +172,15 @@ def populate_test_db(engine):
     common.Config.add_replacement('replaced', 'language', model=common.Language)
     common.Config.add_replacement('gone', None, model=common.Language)
     DBSession.flush()
+
+
+@pytest.fixture
+def db(db):
+    try:
+        yield db
+    finally:
+        DBSession.rollback()
+        VersionedDBSession.rollback()
 
 
 @pytest.fixture

--- a/tests/test_db_util.py
+++ b/tests/test_db_util.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 def test_alembic_version(db):
     from clld.db.util import set_alembic_version, get_alembic_version
 
-    assert get_alembic_version(db) is None
+    assert get_alembic_version(db) != '1234'
     set_alembic_version(db, '1234')
     assert get_alembic_version(db) == '1234'
 


### PR DESCRIPTION
![snap](https://user-images.githubusercontent.com/6342379/35411448-14bb7c4a-0219-11e8-8ed5-8a75a706c878.PNG)
