### PR TITLE
remove admin feature

### DIFF
--- a/src/clld/web/app.py
+++ b/src/clld/web/app.py
@@ -55,10 +55,6 @@ class ClldRequest(Request):
     """Custom Request class."""
 
     @reify
-    def admin(self):
-        return '__admin__' in self.params
-
-    @reify
     def query_params(self):
         """Convenient access to the query parameters of the current request.
 
@@ -182,11 +178,7 @@ class ClldRequest(Request):
         return self.route_url(route, **kw)
 
     def route_url(self, route, *args, **kw):
-        """Facade for Request.route_url, hacking in support for admin routes."""
-        if self.admin:
-            if '_query' not in kw:
-                kw['_query'] = {}
-            kw['_query']['__admin__'] = '1'
+        """Facade for Request.route_url."""
         if '__locale__' in self.params:
             if '_query' not in kw:
                 kw['_query'] = {}


### PR DESCRIPTION
So this follows a suggestion by @xrotwang [over here](https://github.com/dlce-eva/appconfig/issues/243#issuecomment-1027630673).

Tbh I don't really understand what's going on here as I'm neither familiar with pyramid nor the clld codebase. I started to read some code and documentation but wasn't sure, if it was worth the effort.

Anyways, the admin feature that is removed by this commit doesn't seem to be used anywhere else in the code and all tests pass.  So that's a good sign.  Though I feel like the following test maybe should fail because of the 
`res = app.get_html('/?__admin__=1')` , but it doesn't:

https://github.com/clld/clld/blob/a29ee8bd9e7a99bb00098bcb9850fe554660259e/tests/test_functional.py#L26-L41

maybe that's something to investigate.
please tell me if I should dive deeper into the topic.