### PR TITLE
`TypeError` in value datatables

### DIFF
--- a/src/clld/db/models/unitvalue.py
+++ b/src/clld/db/models/unitvalue.py
@@ -67,8 +67,10 @@ class UnitValue(Base,
         return unitparameter_pk
 
     def __str__(self):
-        return self.unitdomainelement.name \
-            if self.unitdomainelement else self.name or self.id
+        if self.unitdomainelement and self.unitdomainelement.name:
+            return self.unitdomainelement.name
+        else:
+            return self.name or self.id
 
 
 #

--- a/src/clld/db/models/value.py
+++ b/src/clld/db/models/value.py
@@ -76,7 +76,10 @@ class Value(Base,
         return res
 
     def __str__(self):
-        return self.domainelement.name if self.domainelement else self.name or self.id
+        if self.domainelement and self.domainelement.name:
+            return self.domainelement.name
+        else:
+            return self.name or self.id
 
 
 class ValueSentence(Base, PolymorphicBaseMixin):

--- a/tests/test_db_models.py
+++ b/tests/test_db_models.py
@@ -109,6 +109,20 @@ def test_UnitValue(db, persist):
     DBSession.flush()
 
 
+def test_unitvalue_to_string():
+    de_name = common.UnitDomainElement(id='de_name', name='Code with name')
+    de_noname = common.UnitDomainElement(id='de_noname')
+    val_de_name = common.UnitValue(id='val_de_name', unitdomainelement=de_name)
+    val_de_noname = common.UnitValue(id='val_de_noname', unitdomainelement=de_noname)
+    val_name = common.UnitValue(id='val_name', name='Value with name')
+    val_noname = common.UnitValue(id='val_noname')
+
+    assert str(val_de_name) == 'Code with name'
+    assert str(val_de_noname) == 'val_de_noname'
+    assert str(val_name) == 'Value with name'
+    assert str(val_noname) == 'val_noname'
+
+
 def test_Identifier():
     i = common.Identifier(id='a', name='a', type=common.IdentifierType.iso.value)
     assert i.url()
@@ -123,6 +137,20 @@ def test_Contribution(data):
 
 def test_Value(data):
     assert 'valueset' in common.Value.first().__json__(None)
+
+
+def test_value_to_string():
+    de_name = common.DomainElement(id='de_name', name='Code with name')
+    de_noname = common.DomainElement(id='de_noname')
+    val_de_name = common.Value(id='val_de_name', domainelement=de_name)
+    val_de_noname = common.Value(id='val_de_noname', domainelement=de_noname)
+    val_name = common.Value(id='val_name', name='Value with name')
+    val_noname = common.Value(id='val_noname')
+
+    assert str(val_de_name) == 'Code with name'
+    assert str(val_de_noname) == 'val_de_noname'
+    assert str(val_name) == 'Value with name'
+    assert str(val_noname) == 'val_noname'
 
 
 def test_Combination(data):


### PR DESCRIPTION
`Value.__str__` caused a `TypeError` when a DomainElement lacks a name.

Applied the same fix to UnitValue as well.