### PR TITLE
Contributor details: tag not closed properly

### DIFF
--- a/src/clld/web/templates/contributor/detail_html.mako
+++ b/src/clld/web/templates/contributor/detail_html.mako
@@ -6,9 +6,8 @@
 <h2>${ctx.name}
 % if ctx.jsondatadict.get("orcid", None):
 <a href="https://orcid.org/${ctx.jsondatadict["orcid"]}"><img style="height:.8em" src="${request.static_url('clld:web/static/images/orcid.svg')}" /></a>
-
-
-% endif</h2>
+% endif
+</h2>
 
 % if ctx.description:
 <p>${ctx.description}</p>


### PR DESCRIPTION
Misplaced `</h2>` tag caused everything below to be rendered as a header.