### PR TITLE
IGT: trailing analysed words dropped to gloss line

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changes
 -------
 
+unreleased
+~~~~~~~~~~
+
+- Addressed rendering issue with IGT examples.
+
 11.2.2
 ~~~~~~
 

--- a/src/clld/web/util/helpers.py
+++ b/src/clld/web/util/helpers.py
@@ -437,9 +437,16 @@ def rendered_sentence(sentence, abbrs=None, fmt='long'):
         for morpheme, gloss in zip_longest(
             analyzed.split('\t'), glossed.split('\t'), fillvalue=''
         ):
+            if gloss:
+                html_gloss = gloss_with_tooltip(gloss)
+            else:
+                # When there are less glosses than morphemes, the trailing
+                # morphemes 'fall down' into the gloss line.  To prevent that we
+                # pad the gloss line with some white space.
+                html_gloss = [literal('&#160;')]
             units.append(HTML.div(
                 HTML.div(morpheme, class_='morpheme'),
-                HTML.div(*gloss_with_tooltip(gloss), **{'class': 'gloss'}),
+                HTML.div(*html_gloss, **{'class': 'gloss'}),
                 class_='gloss-unit'))
 
     return HTML.div(


### PR DESCRIPTION
When an example has less elements in *Gloss* than in *Analyzed_Word*, then you'd expect any trailing words to line up with the analysed word line:

    (1)  This  is   a    green      house
         Das   ist  ein  Treibhaus

However, due to a rendering bug the trailing words ‘fall down’ to the gloss line:

    (1)  This  is   a    green
         Das   ist  ein  Treibhaus  house

This patch fixes that.
