### PR TITLE
add pyproject.toml to template

### DIFF
--- a/src/clld/project_template/{{cookiecutter.directory_name}}/pyproject.toml
+++ b/src/clld/project_template/{{cookiecutter.directory_name}}/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Same idea as https://github.com/cldf/cldfbench/pull/94: Change the web app template, so new apps don't have *pip* nagging about a missing *pyproject.toml*.