### PR TITLE
Fix exception in parameter maps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ unreleased
 ~~~~~~~~~~
 
 - Addressed rendering issue with IGT examples.
+- Addressed exception in maps when some values of a parameter are missing their domain element.
 
 11.2.2
 ~~~~~~

--- a/src/clld/web/adapters/geojson.py
+++ b/src/clld/web/adapters/geojson.py
@@ -183,7 +183,9 @@ class GeoJsonParameter(GeoJson):
         de = req.params.get('domainelement')
         if de:
             return [vs for vs in ctx.valuesets
-                    if vs.values and vs.values[0].domainelement.id == de]
+                    if vs.values
+                    and vs.values[0].domainelement
+                    and vs.values[0].domainelement.id == de]
         return self.get_query(ctx, req)
 
     def get_language(self, ctx, req, valueset):


### PR DESCRIPTION
Parameter maps raised an Exception when a value is missing a domain element.

(And now that I treated the symptom, it's time to scour the data for the actual cause. (\<\_\<)" )
